### PR TITLE
Fix caching subtitle lines with very long durations

### DIFF
--- a/youtube.external.subtitle.js
+++ b/youtube.external.subtitle.js
@@ -85,27 +85,31 @@
 		return Math.floor(seconds / 10);
 	};
 
+	var getCacheNames = function(start, end) {
+		var cacheNames = [];
+		var endCacheName = getCacheName(end);
+
+		for (var i = getCacheName(start); i <= endCacheName; i++) {
+			cacheNames.push(i);
+		}
+
+		return cacheNames;
+	}
+
 	var buildCache = function(subtitles) {
 		var cache = {};
 
 		for (var i in subtitles) {
 			var subtitle = subtitles[i];
 
-			var startCache = getCacheName(subtitle.start);
-			var endCache = getCacheName(subtitle.end);
+			var cacheNames = getCacheNames(subtitle.start, subtitle.end);
 
-			if (!cache[startCache]) {
-				cache[startCache] = [];
-			}
-
-			cache[startCache].push(subtitle);
-
-			if (startCache !== endCache) {
-				if (!cache[endCache]) {
-					cache[endCache] = [];
+			for (var j = 0; j < cacheNames.length; j++) {
+				if (!cache[cacheNames[j]]) {
+					cache[cacheNames[j]] = [];
 				}
 
-				cache[endCache].push(subtitle);
+				cache[cacheNames[j]].push(subtitle);
 			}
 		}
 


### PR DESCRIPTION
Hey, first of all: thanks for making this very neat piece of software! Much appreciated :slightly_smiling_face:!

Then the matter of this pull request: I ran into an issue today where a subtitle line with a very long duration (e.g. lasting from 9 seconds to 21 seconds) was only displayed for a second and then disappeared. Upon examining the code, it turned out that `buildCache` only populates the cache bins for the start and end times of a subtitle line. If there are any bins between those, they are left empty. Not good :sweat_smile:. This pull request fixes that.

I couldn't find any guidelines on contributing to this project anywhere, so I hope this way is ok. If not, please let me know!